### PR TITLE
Fix typo in config.example.yml

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -80,7 +80,7 @@ redis:
   user: ""
 
   # Password to use when authenticating
-  pasword: ""
+  password: ""
 
   # database index
   db: 0


### PR DESCRIPTION
Fixing the typo in config.example.yml, the Redis password authentication will not work because of this typo.